### PR TITLE
Added Waiting component and integrated it into the Container logic.

### DIFF
--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -1,12 +1,13 @@
-import React, { useState } from 'react';
+import { render } from '@testing-library/react';
+import React, { useEffect, useState } from 'react';
 import Banner from './Banner';
 import Board from './Board';
+import Waiting from './Waiting'
 
 
   const Container = ({ socket }) => {
-    const [first, setFirst] = useState(true);
-    const [joined, setJoined] = useState(false);
-
+    const [joined, setJoined] = useState(false); 
+    const [toRender, setToRender] = useState(null);
     function handleSubmit(event) {
       event.preventDefault();
       let id = socket.id;    
@@ -15,9 +16,15 @@ import Board from './Board';
       fetch(url).then((response) => {
         console.log(response.json());
       })
-      console.log(event.target);
       setJoined(true);
+      setToRender(Waiting);  
+    };
+  
+  socket.on('opponentAvailable', (data) => {
+    if(data.status === 'ok') {
+      setToRender(<Board socket={socket}/>);
     }
+  });
 
   const splash = (
     <form
@@ -47,20 +54,27 @@ import Board from './Board';
         />
       </div>
     </form>
-  );
+  ); 
 
-  return (
-    <div>
+  
+  
+  if(!joined) {
+    return (
+      <div>
       <Banner />
-      {!joined ? (
-        splash
-      ) : socket ? (
-        <Board socket={socket} />
-      ) : (
-        <div>Not Connected</div>
-      )}
+      { splash }
     </div>
-  );
+    )
+  } else {
+    return (
+      <div>
+        <Banner />
+        {toRender}
+      </div>
+    );
+  }
 }
-//
+
 export default Container;
+
+

--- a/src/components/Waiting.js
+++ b/src/components/Waiting.js
@@ -1,0 +1,14 @@
+import React from 'react';
+ 
+
+function Waiting() {
+  return (
+    <div className="container mx-auto text-center waiting">
+      <div>
+        <h1 className="display-1">Waiting for opponent...</h1>
+      </div>  
+    </div>
+  );
+}
+
+export default Waiting;

--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,10 @@ body {
   background-color: #1f262a;
 }
 
+h1 {
+  font-family: 'dancing_scriptregular';
+}
+
 .btn {
   width: 100% !important;
   height: 90% !important;
@@ -31,4 +35,12 @@ body {
   cursor: pointer;
   line-height: 100px;
   font-size: 60px;
+}
+
+.waiting {
+  background-color: whitesmoke;
+  color: #01060a;
+  border: 1px solid #1f262a;
+  box-shadow: 2px 2px 2px 2px #779ecb;
+  width: 50% !important;
 }


### PR DESCRIPTION
Changes:
Added Waiting Component (Styling is terrible, I know - suggestions in general on the CSS are welcome).
Integrated Waiting component into Container.

Load app in two tabs.  In first tab, enter player name and hit the Join button.  It should flip to a Waiting screen.  On the 2nd tab, enter player 2's name and hit Join.  When the 2nd tab joins, both tabs should show the board.  Server output should show p1 and p2 in the same game as well.

I believe I've successfully integrated the Waiting component as discussed.  Let me know if you run into any problems.  Going to take a break, then I'll come back and start rewriting the test code.